### PR TITLE
Fixes #6 - Units of geometry section should be angstroms 

### DIFF
--- a/aiida_nwchem/calculations/basic.py
+++ b/aiida_nwchem/calculations/basic.py
@@ -103,7 +103,7 @@ class BasicCalculation(JobCalculation):
         input_filename = tempfolder.get_abs_path(self._DEFAULT_INPUT_FILE)
         with open(input_filename,'w') as f:
             f.write('start {}\ntitle "{}"\n\n'.format(abbreviation,title))
-            f.write('geometry units au\n')
+            f.write('geometry units angstroms\n')
             if add_cell:
                 f.write('  system crystal\n')
                 f.write('    lat_a {}\n    lat_b {}\n    lat_c {}\n'.format(*lat_lengths))


### PR DESCRIPTION
Change the header of the geometry section 'card' to make the units angstroms rather a.u.