### PR TITLE
Adding and registering unused test case for NWChem input generation

### DIFF
--- a/aiida_nwchem/tests/input.py
+++ b/aiida_nwchem/tests/input.py
@@ -17,9 +17,7 @@ import unittest
 from aiida.backends.testbase import AiidaTestCase
 
 
-
-
-class TestNwchem(AiidaTestCase):
+class TestNwchemInput(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")

--- a/setup.json
+++ b/setup.json
@@ -18,8 +18,9 @@
             "nwchem.pymatgen = aiida_nwchem.parsers.nwcpymatgen:NwcpymatgenParser"
         ],
         "aiida.tests": [
+            "nwchem.input = aiida_nwchem.tests.input",
             "nwchem.tcodexporter = aiida_nwchem.tests.tcodexporter"
-        ], 
+        ],
         "aiida.tools.dbexporters.tcod_plugins": [
             "nwchem.nwcpymatgen = aiida_nwchem.tools.dbexporters.tcod_plugins.nwcpymatgen:NwcpymatgenTcodtranslator"
         ]


### PR DESCRIPTION
Bringing to life previously unused test case. With AiiDA installed, it can be executed by ``verdi devel tests db.nwchem.input``.