### PR TITLE
add output for freq task

### DIFF
--- a/src/aiida_nwchem/parsers/nwchem.py
+++ b/src/aiida_nwchem/parsers/nwchem.py
@@ -624,5 +624,7 @@ class NwchemBaseParser(Parser):
                 task_dict['cpu_time'] = result.group(1)
                 task_dict['wall_time'] = result.group(2)
                 break
+            
+        self.out('output_parameters', orm.Dict(dict=task_dict))
 
         return task_dict, nodes

--- a/src/aiida_nwchem/parsers/nwchem.py
+++ b/src/aiida_nwchem/parsers/nwchem.py
@@ -625,6 +625,6 @@ class NwchemBaseParser(Parser):
                 task_dict['wall_time'] = result.group(2)
                 break
             
-        self.out('output_parameters', orm.Dict(dict=task_dict))
+        self.out('output_parameters', orm.Dict(task_dict))
 
         return task_dict, nodes

--- a/src/aiida_nwchem/parsers/nwchem.py
+++ b/src/aiida_nwchem/parsers/nwchem.py
@@ -624,7 +624,7 @@ class NwchemBaseParser(Parser):
                 task_dict['cpu_time'] = result.group(1)
                 task_dict['wall_time'] = result.group(2)
                 break
-            
+
         self.out('output_parameters', orm.Dict(task_dict))
 
         return task_dict, nodes


### PR DESCRIPTION
When run `task freq` in aiida_nwchem, there is no output_parameters for the parsed result.
add `self.out()` to fix.
Need to use this for the heat of formation workflow in aiida using NWchem.